### PR TITLE
Delete aptx

### DIFF
--- a/layouts/aptx
+++ b/layouts/aptx
@@ -1,5 +1,0 @@
-APTx
-q c d w x z p o u ;
-r s t n v y h e i a
-l g b m j k f ' , .
-Apsu


### PR DESCRIPTION
This confuses people when it's suggested as an alternative when they search for `aptwhatever`